### PR TITLE
Fix: Use blockchain name instead of method name in resolvers.settings.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Driver for the iden3 DID method
 ## How to run locally:
 1. Create file `resolvers.settings.yaml` with resolver settings:
     ```yaml
-    iden3:
+    polygon:
         amoy:
             contractAddress: "0xf6..."
             networkURL: "https://polygon-amoy..."

--- a/resolvers.settings.yaml
+++ b/resolvers.settings.yaml
@@ -1,4 +1,4 @@
-iden3:
+polygon:
   amoy:
     contractAddress: 0x1a4cC30f2aA0377b0c3bc9848766D90cb4404124
     networkURL: https://polygon-amoy.g.alchemy.com/v2/nQxE0N6UyGmmiurh735CVn4hZVLkTu0v


### PR DESCRIPTION
### Problem
The resolver fails to configure when using the method name in `resolvers.settings.yaml`.

**Error log:**
```
aditya@192 driver-did-iden3 % docker run -p 8080:8080 driver-did-iden3:local
2025/09/02 19:51:28 failed configure resolver for network 'iden3:amoy': chainID is not registered for iden3:amoy
```

### Solution
Updated the configuration to use the **blockchain name** instead of the **method name**.

### Result
This resolves the chainID registration error and allows the resolver to start correctly.
