### PR TITLE
support Accept / enhance err management

### DIFF
--- a/pkg/app/handler.go
+++ b/pkg/app/handler.go
@@ -92,12 +92,6 @@ func (d *DidDocumentHandler) Get(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-
-	w.Header().Set("Content-type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(didResolution); err != nil {
-		log.Println("failed write response")
-	}
 }
 
 // GetByDNSDomain get a did document by domain.
@@ -112,7 +106,7 @@ func (d *DidDocumentHandler) GetByDNSDomain(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	w.Header().Set("Content-type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(state); err != nil {
 		log.Println("failed write response")

--- a/pkg/document/did.go
+++ b/pkg/document/did.go
@@ -9,10 +9,11 @@ import (
 type ErrorCode string
 
 const (
-	ErrInvalidDID         ErrorCode = "invalidDid"
-	ErrMethodNotSupported ErrorCode = "methodNotSupported"
-	ErrNotFound           ErrorCode = "notFound"
-	ErrUnknownNetwork     ErrorCode = "unknownNetwork"
+	ErrInvalidDID                 ErrorCode = "invalidDid"
+	ErrMethodNotSupported         ErrorCode = "methodNotSupported"
+	ErrNotFound                   ErrorCode = "notFound"
+	ErrUnknownNetwork             ErrorCode = "unknownNetwork"
+	ErrRepresentationNotSupported ErrorCode = "representationNotSupported"
 
 	StateType                            = "Iden3StateInfo2023"
 	Iden3ResolutionMetadataType          = "Iden3ResolutionMetadata"

--- a/pkg/document/did.go
+++ b/pkg/document/did.go
@@ -59,10 +59,9 @@ func NewDidResolution() *DidResolution {
 			VerificationMethod: []verifiable.CommonVerificationMethod{},
 		},
 		DidResolutionMetadata: &DidResolutionMetadata{
-			Context:     []string{iden3ResolutionContext},
-			Type:        Iden3ResolutionMetadataType,
-			ContentType: defaultContentType,
-			Retrieved:   time.Now(),
+			Context:   []string{iden3ResolutionContext},
+			Type:      Iden3ResolutionMetadataType,
+			Retrieved: time.Now(),
 		},
 		DidDocumentMetadata: &DidDocumentMetadata{},
 	}

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -363,8 +363,8 @@ func expectedError(err error) (*document.DidResolution, error) {
 		errors.Is(err, core.ErrBlockchainNotSupportedForDID),
 		errors.Is(err, core.ErrNetworkNotSupportedForDID):
 		return document.NewNetworkNotSupportedForDID(err.Error()), nil
-	case errors.Is(err, core.ErrDIDMethodNotSupported):
-	case errors.Is(err, core.ErrMethodUnknown):
+	case errors.Is(err, core.ErrDIDMethodNotSupported),
+		errors.Is(err, core.ErrMethodUnknown):
 		return document.NewDidMethodNotSupportedResolution(err.Error()), nil
 	}
 	return nil, err

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -82,8 +82,8 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 
 	userDID, err := w3c.ParseDID(did)
 	if err != nil {
-		// mask error to ErrIncorrectDID
-		err = core.ErrIncorrectDID
+		// wrap original error while categorizing it as ErrIncorrectDID
+		err = fmt.Errorf("%w: %v", core.ErrIncorrectDID, err)
 	}
 	errResolution, err := expectedError(err)
 	if errResolution != nil || err != nil {


### PR DESCRIPTION
1. remove didResolutionMetadata contentType from resolve if no accept header passed
2. resolveRepresentation - support Accept headers:
application/did+ld+json → JSON-LD DID Document
application/did+json → JSON DID Document (no JSON-LD processing)
application/did-resolution+json → default one
Unsupported - 406, representationNotSupported error
3. 1.0/identifiers/did:UNKNOWN - return invalidDid, not 500 